### PR TITLE
dpaez/promise support

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,9 @@ function makeRunner (type, limit) {
 
 function put (key, value, opts, cb) {
   cb = getCallback(opts, cb)
+  if (!cb) {
+    cb = createPromiseCb()
+  }
   opts = getOptions(opts)
 
   var self = this
@@ -66,6 +69,9 @@ module.exports.put = put
 
 function del (key, opts, cb) {
   cb = getCallback(opts, cb)
+  if (!cb) {
+    cb = createPromiseCb()
+  }
   opts = getOptions(opts)
 
   var self = this
@@ -95,6 +101,9 @@ module.exports.del = del
 
 function batch (operations, opts, cb) {
   cb = getCallback(opts, cb)
+  if (!cb) {
+    cb = createPromiseCb()
+  }
   opts = getOptions(opts)
 
   var self = this
@@ -144,4 +153,13 @@ function getOptions (options) {
     options = {}
   }
   return options
+}
+
+function createPromiseCb () {
+  return function (err, ...rest) {
+    return new Promise(function (resolve, reject) {
+      if (err) return reject(err)
+      return resolve(...rest)
+    })
+  }
 }

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -37,6 +37,40 @@ tape('test level-hookdown', function (t) {
   }
 })
 
+tape('[promises] test level-hookdown', async function (t) {
+  var sublevel = sub(MemDB(), 'test', { valueEncoding: 'json' })
+  var db = hook(sublevel)
+
+  t.plan(4)
+
+  db.prehooks.push(prehook)
+  db.posthooks.push(posthook)
+
+  var setVal = {
+    beep: 'boop'
+  }
+
+  t.doesNotThrow(async function () {
+    await db.put('main', setVal)
+  }, 'put on wrapped db is error free')
+
+  function prehook (operation, cb) {
+    db.get('main', function (err, value) {
+      t.equal(err.type, 'NotFoundError', 'main operation hasnt been performed in prehook')
+      cb(err.type !== 'NotFoundError' ? err : null)
+    })
+  }
+
+  function posthook (operation, cb) {
+    db.get('main', function (err, value) {
+      t.error(err)
+      if (err) return cb(err)
+      t.deepEqual(value, setVal, 'main put worked fine')
+      cb()
+    })
+  }
+})
+
 tape('test level-hookdown series', function (t) {
   var level = MemDB({ valueEncoding: 'json' })
   var db = hook(level, { type: 'series' })
@@ -71,6 +105,40 @@ tape('test level-hookdown series', function (t) {
   }
 })
 
+tape('[promises] test level-hookdown series', function (t) {
+  var level = MemDB({ valueEncoding: 'json' })
+  var db = hook(level, { type: 'series' })
+
+  t.plan(4)
+
+  db.prehooks.push(prehook)
+  db.posthooks.push(posthook)
+
+  var setVal = {
+    beep: 'boop'
+  }
+
+  t.doesNotThrow(async function () {
+    await db.put('main', setVal)
+  }, 'put on wrapped db is error free')
+
+  function prehook (operation, cb) {
+    db.get('main', function (err, value) {
+      t.equal(err.type, 'NotFoundError', 'main operation hasnt been performed in prehook')
+      cb(err.type !== 'NotFoundError' ? err : null)
+    })
+  }
+
+  function posthook (operation, cb) {
+    db.get('main', function (err, value) {
+      t.error(err)
+      if (err) return cb(err)
+      t.deepEqual(value, setVal, 'main put worked fine')
+      cb()
+    })
+  }
+})
+
 tape('test level-hookdown limit', function (t) {
   var sublevel = sub(MemDB(), 'test', { valueEncoding: 'json' })
   var db = hook(sublevel, { type: 'limit', limit: 2 })
@@ -87,6 +155,40 @@ tape('test level-hookdown limit', function (t) {
   db.put('main', setVal, function (err) {
     t.error(err, 'put on wrapped db is error free')
   })
+
+  function prehook (operation, cb) {
+    db.get('main', function (err, value) {
+      t.equal(err.type, 'NotFoundError', 'main operation hasnt been performed in prehook')
+      cb(err.type !== 'NotFoundError' ? err : null)
+    })
+  }
+
+  function posthook (operation, cb) {
+    db.get('main', function (err, value) {
+      t.error(err)
+      if (err) return cb(err)
+      t.deepEqual(value, setVal, 'main put worked fine')
+      setTimeout(cb, 100)
+    })
+  }
+})
+
+tape('[promises] test level-hookdown limit', function (t) {
+  var sublevel = sub(MemDB(), 'test', { valueEncoding: 'json' })
+  var db = hook(sublevel, { type: 'limit', limit: 2 })
+
+  t.plan(4)
+
+  db.prehooks.push(prehook)
+  db.posthooks.push(posthook)
+
+  var setVal = {
+    beep: 'boop'
+  }
+
+  t.doesNotThrow(async function () {
+    await db.put('main', setVal)
+  }, 'put on wrapped db is error free')
 
   function prehook (operation, cb) {
     db.get('main', function (err, value) {


### PR DESCRIPTION
This PR adds promise support for `level` methods used by this lib. 
This should fix https://github.com/hypermodules/level-auto-index/issues/30

:v: